### PR TITLE
Strengthen invariants for Model 1 and 2

### DIFF
--- a/executable-models/model-1/assertion.ivy
+++ b/executable-models/model-1/assertion.ivy
@@ -22,11 +22,11 @@ object assertion =
 
     relation if_node_is_ready_to_accept_it_must_accept
     definition if_node_is_ready_to_accept_it_must_accept =
-        ~forall N, V . node.ready_to_accept_but_have_not_accepted(N, V)
+        forall N, V. ~node.ready_to_accept_but_have_not_accepted(N, V)
 
     relation if_node_is_ready_to_confirm_it_must_confirm
     definition if_node_is_ready_to_confirm_it_must_confirm =
-        ~forall N, V . node.ready_to_confirm_but_have_not_confirmed(N, V)
+        forall N, V. ~node.ready_to_confirm_but_have_not_confirmed(N, V)
 
     relation accepted_implies_node_heard_itself_accept
     definition accepted_implies_node_heard_itself_accept =

--- a/executable-models/model-1/node.ivy
+++ b/executable-models/model-1/node.ivy
@@ -92,11 +92,18 @@ object node = {
         heard_accept(SELF, SRC, VAL) := false;
     }
 
-    action vote(self_id:id_t, v:val_t) =
+    action vote(self_id:id_t, val:val_t) =
     {
-        require ~voted(self_id, v);
-        voted(self_id, v) := true;
-        heard_vote(self_id, self_id, v) := true;
+        require ~voted(self_id, val);
+        voted(self_id, val) := true;
+        heard_vote(self_id, self_id, val) := true;
+        if ready_to_accept_but_have_not_accepted(self_id, val) {
+            accepted(self_id, val) := true;
+            heard_accept(self_id, self_id, val) := true;
+        };
+        if ready_to_confirm_but_have_not_confirmed(self_id, val) {
+            confirmed(self_id, val) := true;
+        };
     }
 
     action recv_vote(self_id:id_t, src:id_t, val:val_t) =

--- a/executable-models/model-1/proof.ivy
+++ b/executable-models/model-1/proof.ivy
@@ -20,10 +20,10 @@ private {
         forall SELF, VAL. node.accepted(SELF, VAL) -> (exists NODE. node.voted(NODE, VAL))
 
     invariant [if_node_is_ready_to_accept_it_must_accept]
-        ~forall N, V . node.ready_to_accept_but_have_not_accepted(N, V)
+        forall N, V . ~node.ready_to_accept_but_have_not_accepted(N, V)
 
     invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        ~forall N, V . node.ready_to_confirm_but_have_not_confirmed(N, V)
+        forall N, V . ~node.ready_to_confirm_but_have_not_confirmed(N, V)
 
     invariant [accepted_implies_node_heard_itself_accept]
         forall N, V. node.accepted(N, V) -> node.heard_accept(N, N, V)

--- a/executable-models/model-2/assertion.ivy
+++ b/executable-models/model-2/assertion.ivy
@@ -22,11 +22,11 @@ object assertion =
 
     relation if_node_is_ready_to_accept_it_must_accept
     definition if_node_is_ready_to_accept_it_must_accept =
-        ~forall N, V . node.ready_to_accept_but_have_not_accepted(N, V)
+        forall N, V . ~node.ready_to_accept_but_have_not_accepted(N, V)
 
     relation if_node_is_ready_to_confirm_it_must_confirm
     definition if_node_is_ready_to_confirm_it_must_confirm =
-        ~forall N, V . node.ready_to_confirm_but_have_not_confirmed(N, V)
+        forall N, V . ~node.ready_to_confirm_but_have_not_confirmed(N, V)
 
     relation accepted_implies_node_heard_itself_accept
     definition accepted_implies_node_heard_itself_accept =

--- a/executable-models/model-2/proof.ivy
+++ b/executable-models/model-2/proof.ivy
@@ -31,10 +31,10 @@ private {
         forall SELF, VAL. node.accepted(SELF, VAL) -> (exists NODE. node.voted(NODE, VAL))
 
     invariant [if_node_is_ready_to_accept_it_must_accept]
-        ~forall N, V . node.ready_to_accept_but_have_not_accepted(N, V)
+        forall N, V . ~node.ready_to_accept_but_have_not_accepted(N, V)
 
     invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        ~forall N, V . node.ready_to_confirm_but_have_not_confirmed(N, V)
+        forall N, V . ~node.ready_to_confirm_but_have_not_confirmed(N, V)
 
     invariant [if_accept_condition_1_then_must_accept]
         forall V, VAL. node.accept_condition_1(V, VAL) -> node.accepted(V, VAL)


### PR DESCRIPTION
If each node follows the protocol, they will accept as soon as they can. Thus I created an invariant that asserts that no node is in a state where it _can_ accept, but it _hasn't_, and I wrote `~forall N, V . node.ready_to_accept_but_have_not_accepted(N, V)`.
While this invariant isn't wrong (i.e., If each node follows the protocol, this invariant will be always true), what I meant was `forall N, V . ~node.ready_to_accept_but_have_not_accepted(N, V)`.

(The negation should not have been outside `forall`, but it should have been
inside the `forall`.)