### PR TITLE
2-node ballot protocol

### DIFF
--- a/executable-models/ballot-protocol-2-node-network/Makefile
+++ b/executable-models/ballot-protocol-2-node-network/Makefile
@@ -1,0 +1,15 @@
+executable: network.ivy node.ivy sort.ivy assertion.ivy executable.ivy
+	ivy_to_cpp target=repl isolate=executable_runner executable.ivy
+	g++ -O2 executable.cpp -pthread -lpthread -o executable
+
+fuzz: network.ivy node.ivy sort.ivy assertion.ivy fuzz.ivy
+	ivyc target=test isolate=fuzz_runner classname=fuzz fuzz.ivy
+
+proof: network.ivy node.ivy sort.ivy assertion.ivy proof.ivy
+	ivy_check trace=true proof.ivy
+
+format:
+	git ls-tree -r HEAD --name-only | xargs sed -i "s/, /, /g; s/, \s\+/, /g; s/[ \t]*$$//"
+
+clean:
+	rm -f fuzz fuzz.h fuzz.cpp executable executable.h executable.cpp

--- a/executable-models/ballot-protocol-2-node-network/README.md
+++ b/executable-models/ballot-protocol-2-node-network/README.md
@@ -1,0 +1,51 @@
+This directory contains a model for an abstract ballot protocol.
+
+# Description of the network
+
+* There are two nodes.
+* `Q(v_0) = Q(v_1) = {{v_0, v_1}}`.
+* There is no Byzantine failure.
+
+# How to use this
+There are three ways to use this model. Executable model, fuzz testing, and verification.
+
+1. Executable model
+    * Run `make && ./executable` to start a REPL environment.
+      You can invoke actions to manually examine the model.
+      For instance, `node.vote_prepare(0, 1)` makes `Node 0` vote `prepare(Ballot 1)`.
+2. Fuzz testing
+    * Run `make && ./fuzz`.
+      Ivy randomly generates a valid sequence of actions.
+      You can pass the seed as a command line argument. (e.g., `./fuzz seed=123`)
+3. Formal verification
+    * Run `make proof` and Ivy verifies that the invariants specified in `proof.ivy` hold after initialization and any exported actions.
+    * Specifically, it checks that all intact nodes commit the same value.
+
+# Implementation details
+
+* Nodes, quorums and v-blocking sets are all hard-coded.
+* Each node can take any of `confirm_nominate`, `vote_prepare`, or `vote_commit`.
+    * `confirm_nominate` corresponds to confirming `nominate(value)`.
+      This means that the node has been running the nomination protocol,
+      and it confirmed a new value.
+    * `vote_prepare` corresponds to voting `prepare(ballot)`.
+      The node is allowed to perform this action only if it makes sense.
+      (e.g., The value in the ballot is the same as the latest output of the nomination protocol.)
+    * `vote_commit` corresponds to voting `commit(ballot)`.
+      The node can only perform this action only if it makes sense.
+      (e.g., The node must have already confirmed `prepare(ballot)`.)
+* The network can choose to deliver any `{vote, accept}_{prepare, commit}` messages as long as it makes sense to do so.
+    * Messages may be reordered.
+    * Upon receiving a message, the recipient tries to accept and/or confirm appropriate statements.
+
+# Difference between this model and the concrete ballot protocol (CBP for short)
+You might notice that much of the logic of this model doesn't resemble that of the CBP.
+This is because the model is fairly abstract.
+One can perform the exact sequence of actions of the CBP by calling appropriate actions of this model in appropriate order.
+Thus this model does prove some properties of the CBP.
+
+Examples:
+* `PREPARE v i b p p' c.n h.n D` in the CBP encodes a host of conceptual statements as mentioned in Figure 17 of the white paper.
+  This can be achieve by invoking `deliver_vote_prepare`, `deliver_accept_prepare`, `deliver_vote_commit` with appropriate values.
+* Step 9 of the CBP specifies a condition in which the node must update the ballot counter.
+  This can be done by calling `vote_prepare` appropriately.

--- a/executable-models/ballot-protocol-2-node-network/assertion.ivy
+++ b/executable-models/ballot-protocol-2-node-network/assertion.ivy
@@ -1,0 +1,237 @@
+#lang ivy1.7
+
+object assertion =
+{
+    relation heard_vote_prepare_implies_voted_prepare(SELF:id_t, OTHER:id_t, BAL:ballot_t)
+    definition heard_vote_prepare_implies_voted_prepare(SELF, OTHER, BAL) =
+        node.heard_vote_prepare(SELF, OTHER, BAL) -> node.voted_prepare(OTHER, BAL)
+
+    relation heard_accept_prepare_implies_accepted_prepare(SELF:id_t, OTHER:id_t, BAL:ballot_t)
+    definition heard_accept_prepare_implies_accepted_prepare(SELF, OTHER, BAL) =
+        node.heard_accept_prepare(SELF, OTHER, BAL) -> node.accepted_prepare(OTHER, BAL)
+
+    relation accept_prepare_means_at_least_one_vote(SELF:id_t, BAL:ballot_t)
+    definition accept_prepare_means_at_least_one_vote(SELF, BAL) =
+        node.accepted_prepare(SELF, BAL) -> (exists NODE. node.voted_prepare(NODE, BAL))
+
+    relation confirm_prepare_same_after_sufficient_messages(BAL:ballot_t)
+    definition confirm_prepare_same_after_sufficient_messages(BAL) =
+        (exists NODE1, NODE2. node.confirmed_prepare(NODE1, BAL) & ~node.confirmed_prepare(NODE2, BAL))
+            -> (exists NODE1, NODE2. node.accepted_prepare(NODE1, BAL) & ~node.heard_accept_prepare(NODE2, NODE1, BAL))
+
+    relation if_node_is_ready_to_accept_prepare_it_must_accept_prepare(NODE:id_t, BAL:ballot_t)
+    definition if_node_is_ready_to_accept_prepare_it_must_accept_prepare(NODE, BAL) =
+        ~node.ready_to_accept_prepare_but_have_not_accepted_prepare(NODE, BAL)
+
+    relation if_node_is_ready_to_confirm_prepare_it_must_confirm_prepare(NODE:id_t, BAL:ballot_t)
+    definition if_node_is_ready_to_confirm_prepare_it_must_confirm_prepare(NODE, BAL) =
+        ~node.ready_to_confirm_prepare_but_have_not_confirmed_prepare(NODE, BAL)
+
+    relation accepted_prepare_implies_node_heard_itself_accept_prepare(NODE:id_t, BAL:ballot_t)
+    definition accepted_prepare_implies_node_heard_itself_accept_prepare(NODE, BAL) =
+        node.accepted_prepare(NODE, BAL) -> node.heard_accept_prepare(NODE, NODE, BAL)
+
+    relation voted_prepare_implies_node_heard_itself_vote_prepare(NODE:id_t, BAL:ballot_t)
+    definition voted_prepare_implies_node_heard_itself_vote_prepare(NODE, BAL) =
+        node.voted_prepare(NODE, BAL) -> node.heard_vote_prepare(NODE, NODE, BAL)
+
+    relation confirmed_prepare_implies_it_heard_at_least_one_node_accept_prepare(NODE:id_t, BAL:ballot_t)
+    definition confirmed_prepare_implies_it_heard_at_least_one_node_accept_prepare(NODE, BAL) =
+        node.confirmed_prepare(NODE, BAL) -> exists NODE2. NODE ~= NODE2 & node.heard_accept_prepare(NODE, NODE2, BAL)
+
+    relation accepted_prepare_implies_at_least_one_node_voted_prepare(BAL:ballot_t)
+    definition accepted_prepare_implies_at_least_one_node_voted_prepare(BAL) =
+        (exists NODE1. node.accepted_prepare(NODE1, BAL)) -> (exists NODE2. node.voted_prepare(NODE2, BAL))
+
+    relation confirmed_prepare_implies_accepted_prepare(NODE:id_t, BAL:ballot_t)
+    definition confirmed_prepare_implies_accepted_prepare(NODE, BAL) =
+        node.confirmed_prepare(NODE, BAL) -> node.accepted_prepare(NODE, BAL)
+
+    relation confirmed_prepare_implies_there_exists_quorum_accepting_ballot(NODE:id_t, BAL:ballot_t)
+    definition confirmed_prepare_implies_there_exists_quorum_accepting_ballot(NODE, BAL) =
+        node.confirmed_prepare(NODE, BAL) ->
+            (exists Q. node.is_quorum(Q) & node.member(NODE, Q) & node.heard_set_accept_prepare(NODE, Q, BAL))
+
+    relation heard_quorum_accept_prepare_implies_confirmed_prepare(NODE1:id_t, BAL:ballot_t)
+    definition heard_quorum_accept_prepare_implies_confirmed_prepare(NODE1, BAL) =
+        (exists Q.
+            node.is_quorum(Q) &
+            node.member(NODE1, Q) &
+            forall NODE2. (node.member(NODE2, Q) -> node.heard_accept_prepare(NODE1, NODE2, BAL))) -> node.confirmed_prepare(NODE1, BAL)
+
+    relation heard_vote_commit_implies_voted_commit(SELF:id_t, OTHER:id_t, BAL:ballot_t)
+    definition heard_vote_commit_implies_voted_commit(SELF, OTHER, BAL) = node.heard_vote_commit(SELF, OTHER, BAL) -> node.voted_commit(OTHER, BAL)
+
+    relation heard_accept_commit_implies_accepted_commit(SELF:id_t, OTHER:id_t, BAL:ballot_t)
+    definition heard_accept_commit_implies_accepted_commit(SELF, OTHER, BAL) =
+        node.heard_accept_commit(SELF, OTHER, BAL) -> node.accepted_commit(OTHER, BAL)
+
+    relation accept_commit_means_at_least_one_vote(SELF:id_t, BAL:ballot_t)
+    definition accept_commit_means_at_least_one_vote(SELF, BAL) =
+        node.accepted_commit(SELF, BAL) -> (exists NODE. node.voted_commit(NODE, BAL))
+
+    relation confirm_commit_same_after_sufficient_messages(BAL:ballot_t)
+    definition confirm_commit_same_after_sufficient_messages(BAL) =
+        (exists NODE1, NODE2. node.confirmed_commit(NODE1, BAL) & ~node.confirmed_commit(NODE2, BAL))
+            -> (exists NODE1, NODE2. node.accepted_commit(NODE1, BAL) & ~node.heard_accept_commit(NODE2, NODE1, BAL))
+
+    relation if_node_is_ready_to_accept_commit_it_must_accept_commit(NODE:id_t, BAL:ballot_t)
+    definition if_node_is_ready_to_accept_commit_it_must_accept_commit(NODE, BAL) =
+        ~node.ready_to_accept_commit_but_have_not_accepted_commit(NODE, BAL)
+
+    relation if_node_is_ready_to_confirm_commit_it_must_confirm_commit(NODE:id_t, BAL:ballot_t)
+    definition if_node_is_ready_to_confirm_commit_it_must_confirm_commit(NODE, BAL) =
+        ~node.ready_to_confirm_commit_but_have_not_confirmed_commit(NODE, BAL)
+
+    relation accepted_commit_implies_node_heard_itself_accept_commit(NODE:id_t, BAL:ballot_t)
+    definition accepted_commit_implies_node_heard_itself_accept_commit(NODE, BAL) =
+        node.accepted_commit(NODE, BAL) -> node.heard_accept_commit(NODE, NODE, BAL)
+
+    relation voted_commit_implies_node_heard_itself_vote_commit(NODE:id_t, BAL:ballot_t)
+    definition voted_commit_implies_node_heard_itself_vote_commit(NODE, BAL) =
+        node.voted_commit(NODE, BAL) -> node.heard_vote_commit(NODE, NODE, BAL)
+
+    relation confirmed_commit_implies_it_heard_at_least_one_node_accept_commit(NODE:id_t, BAL:ballot_t)
+    definition confirmed_commit_implies_it_heard_at_least_one_node_accept_commit(NODE, BAL) =
+        node.confirmed_commit(NODE, BAL) -> exists NODE2. NODE ~= NODE2 & node.heard_accept_commit(NODE, NODE2, BAL)
+
+    relation accepted_commit_implies_at_least_one_node_voted_commit(BAL:ballot_t)
+    definition accepted_commit_implies_at_least_one_node_voted_commit(BAL) =
+        (exists NODE1. node.accepted_commit(NODE1, BAL)) -> (exists NODE2. node.voted_commit(NODE2, BAL))
+
+    relation confirmed_commit_implies_accepted_commit(NODE:id_t, BAL:ballot_t)
+    definition confirmed_commit_implies_accepted_commit(NODE, BAL) =
+        node.confirmed_commit(NODE, BAL) -> node.accepted_commit(NODE, BAL)
+
+    relation confirmed_commit_implies_there_exists_quorum_accepting_ballot(NODE:id_t, BAL:ballot_t)
+    definition confirmed_commit_implies_there_exists_quorum_accepting_ballot(NODE, BAL) =
+        node.confirmed_commit(NODE, BAL) ->
+            (exists Q. node.is_quorum(Q) & node.member(NODE, Q) & node.heard_set_accept_commit(NODE, Q, BAL))
+
+    relation heard_quorum_accept_commit_implies_confirmed_commit(NODE1:id_t, BAL:ballot_t)
+    definition heard_quorum_accept_commit_implies_confirmed_commit(NODE1, BAL) =
+        (exists Q.
+            node.is_quorum(Q) &
+            node.member(NODE1, Q) &
+            forall NODE2. (node.member(NODE2, Q) -> node.heard_accept_commit(NODE1, NODE2, BAL))) -> node.confirmed_commit(NODE1, BAL)
+
+    relation accepted_commit_implies_accept_commit_condition_1_or_2(NODE:id_t, BAL:ballot_t)
+    definition accepted_commit_implies_accept_commit_condition_1_or_2(NODE, BAL) =
+        node.accepted_commit(NODE, BAL) -> (node.accept_commit_condition_1(NODE, BAL) | node.accept_commit_condition_2(NODE, BAL))
+
+    relation voted_commit_implies_confirmed_prepare(NODE:id_t, BAL:ballot_t)
+    definition voted_commit_implies_confirmed_prepare(NODE, BAL) = node.voted_commit(NODE, BAL) -> node.confirmed_prepare(NODE, BAL)
+
+    relation accepted_commit_implies_confirmed_prepare(NODE:id_t, BAL:ballot_t)
+    definition accepted_commit_implies_confirmed_prepare(NODE, BAL) = node.accepted_commit(NODE, BAL) -> node.confirmed_prepare(NODE, BAL)
+
+    relation confirmed_commit_implies_confirmed_prepare(NODE:id_t, BAL:ballot_t)
+    definition confirmed_commit_implies_confirmed_prepare(NODE, BAL) = node.confirmed_commit(NODE, BAL) -> node.confirmed_prepare(NODE, BAL)
+
+    relation voted_commit_implies_never_voted_abort(NODE:id_t, BAL:ballot_t)
+    definition voted_commit_implies_never_voted_abort(NODE, BAL) = node.voted_commit(NODE, BAL) -> ~node.voted_abort(NODE, BAL)
+
+    relation accepted_commit_implies_never_accepted_abort(NODE:id_t, BAL:ballot_t)
+    definition accepted_commit_implies_never_accepted_abort(NODE, BAL) = node.accepted_commit(NODE, BAL) -> ~node.accepted_abort(NODE, BAL)
+
+    relation confirmed_commit_implies_never_accepted_abort(NODE:id_t, BAL:ballot_t)
+    definition confirmed_commit_implies_never_accepted_abort(NODE, BAL) = node.confirmed_commit(NODE, BAL) -> ~node.accepted_abort(NODE, BAL)
+
+    # Ideally, this would take 4 arguments.
+    # But Ivy can't seem to convert a 4-argument relation into a C++ function.
+    relation confirm_commit_only_same_values(NODE1:id_t, NODE2:id_t)
+    definition confirm_commit_only_same_values(NODE1, NODE2) =
+        forall BAL1, BAL2. (node.confirmed_commit(NODE1, BAL1) & node.confirmed_commit(NODE2, BAL2)) -> compatible(BAL1, BAL2)
+
+    # check_invariants can be called at any moment and it should always pass.
+    action check_invariants =
+    {
+        ensure heard_vote_prepare_implies_voted_prepare(SELF, OTHER, BAL);
+        ensure heard_accept_prepare_implies_accepted_prepare(SELF, OTHER, BAL);
+        ensure accept_prepare_means_at_least_one_vote(SELF, BAL);
+        ensure confirm_prepare_same_after_sufficient_messages(BAL);
+        ensure if_node_is_ready_to_accept_prepare_it_must_accept_prepare(NODE, BAL);
+        ensure if_node_is_ready_to_confirm_prepare_it_must_confirm_prepare(NODE, BAL);
+        ensure accepted_prepare_implies_node_heard_itself_accept_prepare(NODE, BAL);
+        ensure voted_prepare_implies_node_heard_itself_vote_prepare(NODE, BAL);
+        ensure confirmed_prepare_implies_it_heard_at_least_one_node_accept_prepare(NODE, BAL);
+        ensure accepted_prepare_implies_at_least_one_node_voted_prepare(BAL);
+        ensure confirmed_prepare_implies_accepted_prepare(NODE, BAL);
+        ensure confirmed_prepare_implies_there_exists_quorum_accepting_ballot(NODE, BAL);
+        ensure heard_quorum_accept_prepare_implies_confirmed_prepare(NODE, BAL);
+
+        ensure heard_vote_commit_implies_voted_commit(SELF, OTHER, BAL);
+        ensure heard_accept_commit_implies_accepted_commit(SELF, OTHER, BAL);
+        ensure accept_commit_means_at_least_one_vote(SELF, BAL);
+        ensure if_node_is_ready_to_accept_commit_it_must_accept_commit(NODE, BAL);
+        ensure if_node_is_ready_to_confirm_commit_it_must_confirm_commit(NODE, BAL);
+        ensure accepted_commit_implies_node_heard_itself_accept_commit(NODE, BAL);
+        ensure voted_commit_implies_node_heard_itself_vote_commit(NODE, BAL);
+        ensure confirmed_commit_implies_it_heard_at_least_one_node_accept_commit(NODE, BAL);
+        ensure accepted_commit_implies_at_least_one_node_voted_commit(BAL);
+        ensure confirmed_commit_implies_accepted_commit(NODE, BAL);
+        ensure confirmed_commit_implies_there_exists_quorum_accepting_ballot(NODE, BAL);
+        ensure heard_quorum_accept_commit_implies_confirmed_commit(NODE, BAL);
+        ensure voted_commit_implies_confirmed_prepare(NODE, BAL);
+        ensure accepted_commit_implies_confirmed_prepare(NODE, BAL);
+        ensure confirmed_commit_implies_confirmed_prepare(NODE, BAL);
+        ensure voted_commit_implies_never_voted_abort(NODE, BAL);
+        ensure accepted_commit_implies_never_accepted_abort(NODE, BAL);
+        ensure confirmed_commit_implies_never_accepted_abort(NODE, BAL);
+        ensure accepted_commit_implies_accept_commit_condition_1_or_2(NODE, BAL);
+        ensure confirm_commit_only_same_values(NODE1, NODE2);
+    }
+
+    # The following actions are meant to be used when manual testing.
+    # These may not pass in some cases. (e.g., after initialization,
+    # `assert_voted_commit` should not pass.)
+    action assert_voted_prepare(self_id:id_t, val:ballot_t) =
+    {
+        ensure node.voted_prepare(self_id, val);
+    }
+    action assert_accepted_prepare(self_id:id_t, val:ballot_t) =
+    {
+        ensure node.accepted_prepare(self_id, val);
+    }
+    action assert_confirmed_prepare(self_id:id_t, val:ballot_t) =
+    {
+        ensure node.confirmed_prepare(self_id, val);
+    }
+    action assert_not_voted_prepare(self_id:id_t, val:ballot_t) =
+    {
+        ensure ~node.voted_prepare(self_id, val);
+    }
+    action assert_not_accepted_prepare(self_id:id_t, val:ballot_t) =
+    {
+        ensure ~node.accepted_prepare(self_id, val);
+    }
+    action assert_not_confirmed_prepare(self_id:id_t, val:ballot_t) =
+    {
+        ensure ~node.confirmed_prepare(self_id, val);
+    }
+    action assert_voted_commit(self_id:id_t, val:ballot_t) =
+    {
+        ensure node.voted_commit(self_id, val);
+    }
+    action assert_accepted_commit(self_id:id_t, val:ballot_t) =
+    {
+        ensure node.accepted_commit(self_id, val);
+    }
+    action assert_confirmed_commit(self_id:id_t, val:ballot_t) =
+    {
+        ensure node.confirmed_commit(self_id, val);
+    }
+    action assert_not_voted_commit(self_id:id_t, val:ballot_t) =
+    {
+        ensure ~node.voted_commit(self_id, val);
+    }
+    action assert_not_accepted_commit(self_id:id_t, val:ballot_t) =
+    {
+        ensure ~node.accepted_commit(self_id, val);
+    }
+    action assert_not_confirmed_commit(self_id:id_t, val:ballot_t) =
+    {
+        ensure ~node.confirmed_commit(self_id, val);
+    }
+}
+

--- a/executable-models/ballot-protocol-2-node-network/executable.ivy
+++ b/executable-models/ballot-protocol-2-node-network/executable.ivy
@@ -1,0 +1,50 @@
+#lang ivy1.7
+
+include sort
+include node
+include network
+include assertion
+
+# Allow Ivy to cause any number of the following actions.
+
+export node.confirm_nominate
+export node.vote_prepare
+export node.vote_commit
+export network.deliver_vote_prepare
+export network.deliver_accept_prepare
+export network.deliver_vote_commit
+export network.deliver_accept_commit
+
+export assertion.assert_voted_prepare
+export assertion.assert_accepted_prepare
+export assertion.assert_confirmed_prepare
+export assertion.assert_not_voted_prepare
+export assertion.assert_not_accepted_prepare
+export assertion.assert_not_confirmed_prepare
+
+export assertion.assert_voted_commit
+export assertion.assert_accepted_commit
+export assertion.assert_confirmed_commit
+export assertion.assert_not_voted_commit
+export assertion.assert_not_accepted_commit
+export assertion.assert_not_confirmed_commit
+
+export assertion.check_invariants
+
+# While `counter` is unbounded theoretically,
+# it has to be bounded in an executable.
+# Each `ballot_t` is interpreted as a 2-bit vector.
+# Thus we will use the first bit as `x` and the second bit as `n`.
+# More specifically,
+# 0 = {0, 0} => (x = 0, n = 0)
+# 1 = {0, 1} => (x = 0, n = 1)
+# 2 = {1, 0} => (x = 1, n = 0)
+# 3 = {1, 1} => (x = 1, n = 1)
+# Therefore, 0 and 1 are compatible, and 2 and 3 are compatible.
+interpret ballot_t -> bv[2]
+object compatible_definition = {
+    definition compatible(BAL1, BAL2) = (BAL1<=1 & BAL2<=1) | (BAL1>=2 & BAL2>=2)
+}
+
+# Extract a runnable node parameterized by a self-id
+extract executable_runner = node, network, id_t, assertion, ballot_properties, compatible_definition

--- a/executable-models/ballot-protocol-2-node-network/fuzz.ivy
+++ b/executable-models/ballot-protocol-2-node-network/fuzz.ivy
@@ -1,0 +1,34 @@
+#lang ivy1.7
+
+include sort
+include node
+include network
+include assertion
+
+# Allow Ivy to cause any number of the following actions.
+export network.deliver_vote_prepare
+export network.deliver_accept_prepare
+export node.vote_prepare
+export network.deliver_vote_commit
+export network.deliver_accept_commit
+export node.vote_commit
+export node.confirm_nominate
+export assertion.check_invariants
+
+# While `counter` is unbounded theoretically,
+# it has to be bounded in a fuzzer.
+# Each `ballot_t` is interpreted as a 2-bit vector.
+# Thus we will use the first bit as `x` and the second bit as `n`.
+# More specifically,
+# 0 = {0, 0} => (x = 0, n = 0)
+# 1 = {0, 1} => (x = 0, n = 1)
+# 2 = {1, 0} => (x = 1, n = 0)
+# 3 = {1, 1} => (x = 1, n = 1)
+# Therefore, 0 and 1 are compatible, and 2 and 3 are compatible.
+interpret ballot_t -> bv[2]
+object compatible_definition = {
+    definition compatible(BAL1, BAL2) = (BAL1<=1 & BAL2<=1) | (BAL1>=2 & BAL2>=2)
+}
+
+# Extract a runnable node parameterized by a self-id
+extract fuzz_runner = node, network, id_t, assertion, ballot_properties, compatible_definition

--- a/executable-models/ballot-protocol-2-node-network/network.ivy
+++ b/executable-models/ballot-protocol-2-node-network/network.ivy
@@ -1,0 +1,36 @@
+#lang ivy1.7
+
+object network =
+{
+    # Deliver the message "src voted prepare(bal)" to dst.
+    action deliver_vote_prepare(src:id_t, dst:id_t, bal:ballot_t) =
+    {
+        require node.voted_prepare(src, bal);
+        require ~node.heard_vote_prepare(dst, src, bal);
+        call node.recv_vote_prepare(dst, src, bal);
+    }
+
+    # Deliver the message "src accepted prepare(bal)" to dst.
+    action deliver_accept_prepare(src:id_t, dst:id_t, bal:ballot_t) =
+    {
+        require node.accepted_prepare(src, bal);
+        require ~node.heard_accept_prepare(dst, src, bal);
+        call node.recv_accept_prepare(dst, src, bal);
+    }
+
+    # Deliver the message "src voted commit(bal)" to dst.
+    action deliver_vote_commit(src:id_t, dst:id_t, bal:ballot_t) =
+    {
+        require node.voted_commit(src, bal);
+        require ~node.heard_vote_commit(dst, src, bal);
+        call node.recv_vote_commit(dst, src, bal);
+    }
+
+    # Deliver the message "src accepted commit(bal)" to dst.
+    action deliver_accept_commit(src:id_t, dst:id_t, bal:ballot_t) =
+    {
+        require node.accepted_commit(src, bal);
+        require ~node.heard_accept_commit(dst, src, bal);
+        call node.recv_accept_commit(dst, src, bal);
+    }
+}

--- a/executable-models/ballot-protocol-2-node-network/node.ivy
+++ b/executable-models/ballot-protocol-2-node-network/node.ivy
@@ -1,0 +1,317 @@
+#lang ivy1.7
+
+object node = {
+    # For some reason treating the following relation definitions as assignments in
+    # an 'after init' block means that Ivy considers the possibility of the
+    # relations having different values, when exploring possible prestates for
+    # actions, though it seems like it should not.
+
+    relation member(X:id_t, S:set_t)
+    definition member(X:id_t, S:set_t) =
+      (X=0 & S=1) |
+      (X=1 & S=2) |
+      (X=0 & S=3) |
+      (X=1 & S=3)
+
+    relation is_quorum(S:set_t)
+    definition is_quorum(S:set_t) = S=3
+
+    relation is_v_blocking(V:id_t, S:set_t)
+    definition is_v_blocking(V:id_t, S:set_t) =
+      ~((V=0 & S=0) |
+        (V=1 & S=0))
+
+    # These relations are state variables, and will
+    # be updated during actions below.
+    relation voted_prepare(SELF:id_t, BAL:ballot_t)
+    relation accepted_prepare(SELF:id_t, BAL:ballot_t)
+    relation confirmed_prepare(SELF:id_t, BAL:ballot_t)
+    relation heard_vote_prepare(SELF:id_t, SRC:id_t, BAL:ballot_t)
+    relation heard_accept_prepare(SELF:id_t, SRC:id_t, BAL:ballot_t)
+    relation voted_commit(SELF:id_t, BAL:ballot_t)
+    relation accepted_commit(SELF:id_t, BAL:ballot_t)
+    relation confirmed_commit(SELF:id_t, BAL:ballot_t)
+    relation heard_vote_commit(SELF:id_t, SRC:id_t, BAL:ballot_t)
+    relation heard_accept_commit(SELF:id_t, SRC:id_t, BAL:ballot_t)
+    relation compatible_with_nomination_output(SELF:id_t, BAL:ballot_t)
+
+    after init {
+        voted_prepare(SELF, BAL) := false;
+        accepted_prepare(SELF, BAL) := false;
+        confirmed_prepare(SELF, BAL) := false;
+        heard_vote_prepare(SELF, SRC, BAL) := false;
+        heard_accept_prepare(SELF, SRC, BAL) := false;
+        voted_commit(SELF, BAL) := false;
+        accepted_commit(SELF, BAL) := false;
+        confirmed_commit(SELF, BAL) := false;
+        heard_vote_commit(SELF, SRC, BAL) := false;
+        heard_accept_commit(SELF, SRC, BAL) := false;
+        compatible_with_nomination_output(SELF, BAL) := false;
+    }
+
+    # The remaining relations are definitions, used as
+    # abbreviations inside logical formulas elsewhere.
+    relation heard_set_vote_or_accept_prepare(SELF:id_t, SET:set_t, BAL:ballot_t)
+    definition heard_set_vote_or_accept_prepare(SELF, S, BAL) =
+        forall V. member(V, S) ->
+            (
+                heard_vote_prepare(SELF, V, BAL) |
+                heard_accept_prepare(SELF, V, BAL)
+            )
+
+    relation heard_set_accept_prepare(SELF:id_t, SET:set_t, BAL:ballot_t)
+    definition heard_set_accept_prepare(SELF, S, BAL) =
+        forall V. member(V, S) -> heard_accept_prepare(SELF, V, BAL)
+
+    relation accept_prepare_condition_1(SELF:id_t, BAL:ballot_t)
+    definition accept_prepare_condition_1(SELF, BAL) =
+        exists Q.
+            (
+                is_quorum(Q) &
+                member(SELF, Q) &
+                heard_set_vote_or_accept_prepare(SELF, Q, BAL)
+            )
+
+    relation accept_prepare_condition_2(SELF:id_t, BAL:ballot_t)
+    definition accept_prepare_condition_2(SELF, BAL) =
+        exists S.
+            (
+                is_v_blocking(SELF, S) &
+                heard_set_accept_prepare(SELF, S, BAL)
+            )
+
+    relation voted_to_commit_lesser_incompatible_ballot_t(SELF:id_t, BAL:ballot_t)
+    definition voted_to_commit_lesser_incompatible_ballot_t(SELF, BAL) =
+        exists BAL2. ~compatible(BAL, BAL2) & BAL2 < BAL & voted_commit(SELF, BAL2)
+
+    relation accepted_to_commit_lesser_incompatible_ballot_t(SELF:id_t, BAL:ballot_t)
+    definition accepted_to_commit_lesser_incompatible_ballot_t(SELF, BAL) =
+        exists BAL2. ~compatible(BAL, BAL2) & BAL2 < BAL & accepted_commit(SELF, BAL2)
+
+    relation ready_to_accept_prepare_but_have_not_accepted_prepare(SELF:id_t, BAL:ballot_t)
+    definition ready_to_accept_prepare_but_have_not_accepted_prepare(SELF, BAL) =
+        ~accepted_prepare(SELF, BAL) &
+        ~accepted_to_commit_lesser_incompatible_ballot_t(SELF, BAL) &
+        (accept_prepare_condition_1(SELF, BAL) |
+	     accept_prepare_condition_2(SELF, BAL))
+
+    relation ready_to_confirm_prepare_but_have_not_confirmed_prepare(SELF:id_t, BAL:ballot_t)
+    definition ready_to_confirm_prepare_but_have_not_confirmed_prepare(SELF, BAL) =
+        ~confirmed_prepare(SELF, BAL) &
+        exists Q.
+            (
+                is_quorum(Q) &
+                member(SELF, Q) &
+                heard_set_accept_prepare(SELF, Q, BAL)
+            )
+
+    relation heard_set_vote_or_accept_commit(SELF:id_t, SET:set_t, BAL:ballot_t)
+    definition heard_set_vote_or_accept_commit(SELF, S, BAL) =
+        forall V. member(V, S) ->
+            (
+                heard_vote_commit(SELF, V, BAL) |
+                heard_accept_commit(SELF, V, BAL)
+            )
+
+    relation heard_set_accept_commit(SELF:id_t, SET:set_t, BAL:ballot_t)
+    definition heard_set_accept_commit(SELF, S, BAL) =
+        forall V. member(V, S) -> heard_accept_commit(SELF, V, BAL)
+
+    relation accept_commit_condition_1(SELF:id_t, BAL:ballot_t)
+    definition accept_commit_condition_1(SELF, BAL) =
+        exists Q.
+            (
+                is_quorum(Q) &
+                member(SELF, Q) &
+                heard_set_vote_or_accept_commit(SELF, Q, BAL)
+            )
+
+    relation accept_commit_condition_2(SELF:id_t, BAL:ballot_t)
+    definition accept_commit_condition_2(SELF, BAL) =
+        exists S.
+            (
+                is_v_blocking(SELF, S) &
+                heard_set_accept_commit(SELF, S, BAL)
+            )
+
+    # Checks whether SELF has voted abort(BAL).
+    # By definition, a ballot b is prepared if and only if { abort(b') | b' ⋦ b }.
+    # Therefore, if SELF has voted to prepare greater, incompatible BAL2,
+    # then that implies that SELF has voted abort(BAL).
+    relation voted_abort(SELF:id_t, BAL:ballot_t)
+    definition voted_abort(SELF, BAL) =
+        exists BAL2. BAL2 > BAL & ~compatible(BAL, BAL2) & voted_prepare(SELF, BAL2)
+
+    # See the comment above for voted_abort.
+    relation accepted_abort(SELF:id_t, BAL:ballot_t)
+    definition accepted_abort(SELF, BAL) =
+        exists BAL2. BAL2 > BAL & ~compatible(BAL, BAL2) & accepted_prepare(SELF, BAL2)
+
+    # Checks whether SELF is ready to accept, but has not accepted commit(BAL).
+    # 1. `~accepted_commit(SELF, BAL)`
+    #    -> trivial
+    # 2. `~accepted_abort(SELF, BAL)`
+    #    -> We can accept only if we have not aborted it.
+    # 3. `confirmed_prepare(SELF, BAL)`
+    #    -> This condition is necessary since P.20 of the white paper states:
+    #
+    #       > To commit a ballot b and externalize its value b.x,
+    #       > SCP nodes first accept and confirm b is prepared, then accept and confirm commit b.
+    relation ready_to_accept_commit_but_have_not_accepted_commit(SELF:id_t, BAL:ballot_t)
+    definition ready_to_accept_commit_but_have_not_accepted_commit(SELF, BAL) =
+        ~accepted_commit(SELF, BAL) &
+        ~accepted_abort(SELF, BAL) &
+        confirmed_prepare(SELF, BAL) &
+        (accept_commit_condition_1(SELF, BAL) |
+	     accept_commit_condition_2(SELF, BAL))
+
+    relation ready_to_confirm_commit_but_have_not_confirmed_commit(SELF:id_t, BAL:ballot_t)
+    definition ready_to_confirm_commit_but_have_not_confirmed_commit(SELF, BAL) =
+        ~confirmed_commit(SELF, BAL) &
+        exists Q.
+            (
+                is_quorum(Q) &
+                member(SELF, Q) &
+                heard_set_accept_commit(SELF, Q, BAL)
+            )
+
+    # `self_id` confirms `NOMINATE(bal.x)`.
+    # We can't just pass the value here since this model doesn't know
+    # about `bal.x` and `bal.n`.
+    action confirm_nominate(self_id:id_t, bal:ballot_t) =
+    {
+        compatible_with_nomination_output(self_id, BAL) := compatible(BAL, bal);
+    }
+
+    # self_id votes to prepare bal.
+    # NB: prepare(bal) is actually a collection of statements,
+    # not one statement. By definition, voting to prepare bal is equivalent to
+    # voting for each statement in { abort(bal') | bal' ⋦ bal }.
+    action vote_prepare(self_id:id_t, bal:ballot_t) =
+    {
+        require ~voted_prepare(self_id, bal);
+        # Since we're trying to vote to prepare bal,
+        # we must make sure that we haven't voted or accepted to commit
+        # a lesser, incompatible ballot.
+        #
+        # P.22 of the white paper states:
+        #
+        # > For a given ballot, commit and abort are contradictory,
+        # > so a well-behaved node may vote for at most one of them.
+        require ~voted_to_commit_lesser_incompatible_ballot_t(self_id, bal);
+        require ~accepted_to_commit_lesser_incompatible_ballot_t(self_id, bal);
+
+        require compatible_with_nomination_output(self_id, bal);
+
+        voted_prepare(self_id, bal) := true;
+        heard_vote_prepare(self_id, self_id, bal) := true;
+        if ready_to_accept_prepare_but_have_not_accepted_prepare(self_id, bal) {
+            accepted_prepare(self_id, bal) := true;
+            heard_accept_prepare(self_id, self_id, bal) := true;
+        };
+        if ready_to_confirm_prepare_but_have_not_confirmed_prepare(self_id, bal) {
+            confirmed_prepare(self_id, bal) := true;
+            # Confirming `prepare(bal)` might let us accept `commit(bal)`
+            # based on messages that we've already received.
+            if ready_to_accept_commit_but_have_not_accepted_commit(self_id, bal) {
+                accepted_commit(self_id, bal) := true;
+                heard_accept_commit(self_id, self_id, bal) := true;
+            };
+            if ready_to_confirm_commit_but_have_not_confirmed_commit(self_id, bal) {
+                confirmed_commit(self_id, bal) := true;
+            };
+        };
+    }
+
+    action recv_vote_prepare(self_id:id_t, src:id_t, bal:ballot_t) =
+    {
+        heard_vote_prepare(self_id, src, bal) := true;
+        if ready_to_accept_prepare_but_have_not_accepted_prepare(self_id, bal) {
+            accepted_prepare(self_id, bal) := true;
+            heard_accept_prepare(self_id, self_id, bal) := true;
+        };
+        if ready_to_confirm_prepare_but_have_not_confirmed_prepare(self_id, bal) {
+            confirmed_prepare(self_id, bal) := true;
+            # Confirming `prepare(bal)` might let us accept `commit(bal)`
+            # based on messages that we've already received.
+            if ready_to_accept_commit_but_have_not_accepted_commit(self_id, bal) {
+                accepted_commit(self_id, bal) := true;
+                heard_accept_commit(self_id, self_id, bal) := true;
+            };
+            if ready_to_confirm_commit_but_have_not_confirmed_commit(self_id, bal) {
+                confirmed_commit(self_id, bal) := true;
+            };
+        };
+    }
+
+    action recv_accept_prepare(self_id:id_t, src:id_t, bal:ballot_t) =
+    {
+        heard_accept_prepare(self_id, src, bal) := true;
+        if ready_to_accept_prepare_but_have_not_accepted_prepare(self_id, bal) {
+            accepted_prepare(self_id, bal) := true;
+            heard_accept_prepare(self_id, self_id, bal) := true;
+        };
+        if ready_to_confirm_prepare_but_have_not_confirmed_prepare(self_id, bal) {
+            confirmed_prepare(self_id, bal) := true;
+            # Confirming `prepare(bal)` might let us accept `commit(bal)`
+            # based on messages that we've already received.
+            if ready_to_accept_commit_but_have_not_accepted_commit(self_id, bal) {
+                accepted_commit(self_id, bal) := true;
+                heard_accept_commit(self_id, self_id, bal) := true;
+            };
+            if ready_to_confirm_commit_but_have_not_confirmed_commit(self_id, bal) {
+                confirmed_commit(self_id, bal) := true;
+            };
+        };
+    }
+
+    action vote_commit(self_id:id_t, bal:ballot_t) =
+    {
+        require ~voted_commit(self_id, bal);
+
+        # We need to make sure that we have confirmed prepare(bal).
+        #
+        # > More precisely, then, commit b is valid to vote for only if b is confirmed prepared,
+        # > which nodes ensure through federated voting on the corresponding abort statements.
+        #
+        # from P.22 of the white paper.
+        require confirmed_prepare(self_id, bal);
+
+        require ~voted_abort(self_id, bal);
+        require ~accepted_abort(self_id, bal);
+
+        voted_commit(self_id, bal) := true;
+        heard_vote_commit(self_id, self_id, bal) := true;
+        if ready_to_accept_commit_but_have_not_accepted_commit(self_id, bal) {
+            accepted_commit(self_id, bal) := true;
+            heard_accept_commit(self_id, self_id, bal) := true;
+        };
+        if ready_to_confirm_commit_but_have_not_confirmed_commit(self_id, bal) {
+            confirmed_commit(self_id, bal) := true;
+        };
+    }
+
+    action recv_vote_commit(self_id:id_t, src:id_t, bal:ballot_t) =
+    {
+        heard_vote_commit(self_id, src, bal) := true;
+        if ready_to_accept_commit_but_have_not_accepted_commit(self_id, bal) {
+            accepted_commit(self_id, bal) := true;
+            heard_accept_commit(self_id, self_id, bal) := true;
+        };
+        if ready_to_confirm_commit_but_have_not_confirmed_commit(self_id, bal) {
+            confirmed_commit(self_id, bal) := true;
+        };
+    }
+
+    action recv_accept_commit(self_id:id_t, src:id_t, bal:ballot_t) =
+    {
+        heard_accept_commit(self_id, src, bal) := true;
+        if ready_to_accept_commit_but_have_not_accepted_commit(self_id, bal) {
+            accepted_commit(self_id, bal) := true;
+            heard_accept_commit(self_id, self_id, bal) := true;
+        };
+        if ready_to_confirm_commit_but_have_not_confirmed_commit(self_id, bal) {
+            confirmed_commit(self_id, bal) := true;
+        };
+    }
+}

--- a/executable-models/ballot-protocol-2-node-network/proof.ivy
+++ b/executable-models/ballot-protocol-2-node-network/proof.ivy
@@ -1,0 +1,57 @@
+#lang ivy1.7
+
+include sort
+include node
+include network
+include assertion
+
+# Ivy checks that the following invariants always hold if we start with the initialization state
+# (i.e., `after init`) and continuously apply the exported actions below.
+
+# We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
+private {
+    invariant assertion.heard_vote_prepare_implies_voted_prepare(SELF, OTHER, BAL)
+    invariant assertion.heard_accept_prepare_implies_accepted_prepare(SELF, OTHER, BAL)
+    invariant assertion.accept_prepare_means_at_least_one_vote(NODE, BAL)
+    invariant assertion.if_node_is_ready_to_accept_prepare_it_must_accept_prepare(NODE, BAL)
+    invariant assertion.if_node_is_ready_to_confirm_prepare_it_must_confirm_prepare(NODE, BAL)
+    invariant assertion.accepted_prepare_implies_node_heard_itself_accept_prepare(NODE, BAL)
+    invariant assertion.voted_prepare_implies_node_heard_itself_vote_prepare(NODE, BAL)
+    invariant assertion.confirmed_prepare_implies_it_heard_at_least_one_node_accept_prepare(NODE, BAL)
+    invariant assertion.accepted_prepare_implies_at_least_one_node_voted_prepare(BAL)
+    invariant assertion.confirmed_prepare_implies_accepted_prepare(NODE, BAL)
+    invariant assertion.confirmed_prepare_implies_there_exists_quorum_accepting_ballot(NODE, BAL)
+    invariant assertion.heard_quorum_accept_prepare_implies_confirmed_prepare(NODE, BAL)
+
+    invariant assertion.heard_vote_commit_implies_voted_commit(SELF, OTHER, BAL)
+    invariant assertion.heard_accept_commit_implies_accepted_commit(SELF, OTHER, BAL)
+    invariant assertion.accept_commit_means_at_least_one_vote(NODE, BAL)
+    invariant assertion.if_node_is_ready_to_accept_commit_it_must_accept_commit(NODE, BAL)
+    invariant assertion.if_node_is_ready_to_confirm_commit_it_must_confirm_commit(NODE, BAL)
+    invariant assertion.accepted_commit_implies_node_heard_itself_accept_commit(NODE, BAL)
+    invariant assertion.voted_commit_implies_node_heard_itself_vote_commit(NODE, BAL)
+    invariant assertion.confirmed_commit_implies_it_heard_at_least_one_node_accept_commit(NODE, BAL)
+    invariant assertion.accepted_commit_implies_at_least_one_node_voted_commit(BAL)
+    invariant assertion.confirmed_commit_implies_accepted_commit(NODE, BAL)
+    invariant assertion.confirmed_commit_implies_there_exists_quorum_accepting_ballot(NODE, BAL)
+    invariant assertion.heard_quorum_accept_commit_implies_confirmed_commit(NODE, BAL)
+    invariant assertion.voted_commit_implies_confirmed_prepare(NODE, BAL)
+    invariant assertion.accepted_commit_implies_confirmed_prepare(NODE, BAL)
+    invariant assertion.confirmed_commit_implies_confirmed_prepare(NODE, BAL)
+    invariant assertion.voted_commit_implies_never_voted_abort(NODE, BAL)
+    invariant assertion.accepted_commit_implies_never_accepted_abort(NODE, BAL)
+    invariant assertion.confirmed_commit_implies_never_accepted_abort(NODE, BAL)
+    invariant assertion.accepted_commit_implies_accept_commit_condition_1_or_2(NODE, BAL)
+}
+
+invariant assertion.confirm_prepare_same_after_sufficient_messages(BAL)
+invariant [when_nodes_confirm_commit_they_are_all_compatible]
+        assertion.confirm_commit_only_same_values(NODE1, NODE2)
+
+export network.deliver_vote_prepare
+export network.deliver_accept_prepare
+export node.vote_prepare
+export network.deliver_vote_commit
+export network.deliver_accept_commit
+export node.vote_commit
+export node.confirm_nominate

--- a/executable-models/ballot-protocol-2-node-network/sort.ivy
+++ b/executable-models/ballot-protocol-2-node-network/sort.ivy
@@ -1,0 +1,26 @@
+#lang ivy1.7
+
+include order
+
+type id_t
+type set_t
+type ballot_t
+
+interpret id_t -> bv[1]
+interpret set_t -> bv[2]
+
+# `compatible(BAL1, BAL2) ⟺   BAL1.x = BAL2.x`
+# Note that `b1 ⋦ b2 ⟺   b1 < b2 & ~compatible(b1, b2)`.
+relation compatible(BAL1:ballot_t, BAL2:ballot_t)
+
+trusted isolate ballot_properties = {
+    # > Ballots are totally ordered, with b.n more significant than b.x.
+    # P.22 of the white paper.
+    instantiate totally_ordered(ballot_t)
+
+    # As `compatible(BAL1, BAL2) ⟺   BAL1.x = BAL2.x`,
+    # it is necessary that `compatible` is an equivalence relation.
+    axiom compatible(BAL, BAL)
+    axiom compatible(BAL1, BAL2) -> compatible(BAL2, BAL1)
+    axiom (compatible(BAL1, BAL2) & compatible(BAL2, BAL3)) -> compatible(BAL1, BAL3)
+}


### PR DESCRIPTION
It proves that if two nodes confirmed `commit(bal1)` and `commit(bal2)`, respectively, their values must be the same.

This PR also contains the fuzzer and executable.