### PR TITLE
Remove unnecessary invariants

### DIFF
--- a/executable-models/ballot-protocol-2-node-network/proof.ivy
+++ b/executable-models/ballot-protocol-2-node-network/proof.ivy
@@ -10,38 +10,15 @@ include assertion
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant assertion.heard_vote_prepare_implies_voted_prepare(SELF, OTHER, BAL)
     invariant assertion.heard_accept_prepare_implies_accepted_prepare(SELF, OTHER, BAL)
-    invariant assertion.accept_prepare_means_at_least_one_vote(NODE, BAL)
-    invariant assertion.if_node_is_ready_to_accept_prepare_it_must_accept_prepare(NODE, BAL)
-    invariant assertion.if_node_is_ready_to_confirm_prepare_it_must_confirm_prepare(NODE, BAL)
-    invariant assertion.accepted_prepare_implies_node_heard_itself_accept_prepare(NODE, BAL)
-    invariant assertion.voted_prepare_implies_node_heard_itself_vote_prepare(NODE, BAL)
-    invariant assertion.confirmed_prepare_implies_it_heard_at_least_one_node_accept_prepare(NODE, BAL)
-    invariant assertion.accepted_prepare_implies_at_least_one_node_voted_prepare(BAL)
-    invariant assertion.confirmed_prepare_implies_accepted_prepare(NODE, BAL)
     invariant assertion.confirmed_prepare_implies_there_exists_quorum_accepting_ballot(NODE, BAL)
     invariant assertion.heard_quorum_accept_prepare_implies_confirmed_prepare(NODE, BAL)
 
     invariant assertion.heard_vote_commit_implies_voted_commit(SELF, OTHER, BAL)
     invariant assertion.heard_accept_commit_implies_accepted_commit(SELF, OTHER, BAL)
-    invariant assertion.accept_commit_means_at_least_one_vote(NODE, BAL)
-    invariant assertion.if_node_is_ready_to_accept_commit_it_must_accept_commit(NODE, BAL)
-    invariant assertion.if_node_is_ready_to_confirm_commit_it_must_confirm_commit(NODE, BAL)
-    invariant assertion.accepted_commit_implies_node_heard_itself_accept_commit(NODE, BAL)
-    invariant assertion.voted_commit_implies_node_heard_itself_vote_commit(NODE, BAL)
-    invariant assertion.confirmed_commit_implies_it_heard_at_least_one_node_accept_commit(NODE, BAL)
-    invariant assertion.accepted_commit_implies_at_least_one_node_voted_commit(BAL)
-    invariant assertion.confirmed_commit_implies_accepted_commit(NODE, BAL)
     invariant assertion.confirmed_commit_implies_there_exists_quorum_accepting_ballot(NODE, BAL)
-    invariant assertion.heard_quorum_accept_commit_implies_confirmed_commit(NODE, BAL)
-    invariant assertion.voted_commit_implies_confirmed_prepare(NODE, BAL)
     invariant assertion.accepted_commit_implies_confirmed_prepare(NODE, BAL)
-    invariant assertion.confirmed_commit_implies_confirmed_prepare(NODE, BAL)
-    invariant assertion.voted_commit_implies_never_voted_abort(NODE, BAL)
     invariant assertion.accepted_commit_implies_never_accepted_abort(NODE, BAL)
-    invariant assertion.confirmed_commit_implies_never_accepted_abort(NODE, BAL)
-    invariant assertion.accepted_commit_implies_accept_commit_condition_1_or_2(NODE, BAL)
 }
 
 invariant assertion.confirm_prepare_same_after_sufficient_messages(BAL)

--- a/executable-models/general-nomination-protocol/proof.ivy
+++ b/executable-models/general-nomination-protocol/proof.ivy
@@ -9,18 +9,6 @@ include network
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant [voted_or_not_voted] forall V, VAL. node.voted(V, VAL) | ~node.voted(V, VAL)
-
-    invariant [accepted_or_not_accepted] forall V, VAL. node.accepted(V, VAL) | ~node.accepted(V, VAL)
-
-    invariant [heard_accept_or_not_heard_accept] forall V, W, VAL. node.heard_accept(V, W, VAL) | ~node.heard_accept(V, W, VAL)
-
-    invariant [heard_vote_or_not_heard_vote] forall V, W, VAL. node.heard_vote(V, W, VAL) | ~node.heard_vote(V, W, VAL)
-
-    invariant [voted_implies_heard_itself_vote] forall V, VAL. (node.intact(V) & node.voted(V, VAL)) -> node.heard_vote(V, V, VAL)
-
-    invariant [accepted_implies_heard_itself_accept] forall V, VAL. (node.intact(V) & node.accepted(V, VAL)) -> node.heard_accept(V, V, VAL)
-
     invariant [heard_vote_implies_voted]
         forall SELF, OTHER, VAL. (node.intact(SELF) & node.intact(OTHER) & node.heard_vote(SELF, OTHER, VAL)) -> node.voted(OTHER, VAL)
 
@@ -30,29 +18,14 @@ private {
     invariant [accept_means_at_least_one_vote]
         forall SELF, VAL. (node.intact(SELF) & node.accepted(SELF, VAL)) -> (exists NODE. node.intact(NODE) & node.voted(NODE, VAL))
 
-    invariant [if_node_is_ready_to_accept_it_must_accept]
-        forall NODE. (node.intact(NODE) -> forall VAL. ~node.ready_to_accept_but_have_not_accepted(NODE, VAL))
-
-    invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        forall NODE. (node.intact(NODE) -> forall VAL. ~node.ready_to_confirm_but_have_not_confirmed(NODE, VAL))
-
     invariant [if_accept_condition_1_then_must_accept]
         forall V, VAL. (node.intact(V) & node.accept_condition_1(V, VAL)) -> node.accepted(V, VAL)
 
     invariant [if_accept_condition_2_then_must_accept]
         forall V, VAL. (node.intact(V) & node.accept_condition_2(V, VAL)) -> node.accepted(V, VAL)
 
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. (node.intact(N) & node.accepted(N, V)) -> node.heard_accept(N, N, V)
-
-    invariant [voted_implies_node_heard_itself_vote]
-        forall N, V. (node.intact(N) & node.voted(N, V)) -> node.heard_vote(N, N, V)
-
     invariant [accepted_implies_at_least_one_node_voted]
         forall V. (exists N1. node.intact(N1) & node.accepted(N1, V)) -> (exists N2. node.intact(N2) & node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V. (node.intact(N) & node.confirmed(N, V)) -> node.accepted(N, V)
 
     relation heard_my_quorum_accept(N:id_t, V:val_t)
     definition heard_my_quorum_accept(N, V) =
@@ -61,9 +34,6 @@ private {
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . (node.intact(N) & node.confirmed(N, V)) ->
             heard_my_quorum_accept(N, V)
-
-    invariant [if_there_exists_quorum_accepting_value_then_confirmed]
-        forall N, V. ((node.intact(N) & exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V)) -> node.confirmed(N, V))
 
     invariant [heard_quorum_accept_implies_confirmed]
         forall N1, V. (node.intact(N1) & (heard_my_quorum_accept(N1, V))) -> node.confirmed(N1, V)

--- a/executable-models/model-1/proof.ivy
+++ b/executable-models/model-1/proof.ivy
@@ -19,26 +19,8 @@ private {
     invariant [accept_means_at_least_one_vote]
         forall SELF, VAL. node.accepted(SELF, VAL) -> (exists NODE. node.voted(NODE, VAL))
 
-    invariant [if_node_is_ready_to_accept_it_must_accept]
-        forall N, V . ~node.ready_to_accept_but_have_not_accepted(N, V)
-
-    invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        forall N, V . ~node.ready_to_confirm_but_have_not_confirmed(N, V)
-
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. node.accepted(N, V) -> node.heard_accept(N, N, V)
-
-    invariant [voted_implies_node_heard_itself_vote]
-        forall N, V. node.voted(N, V) -> node.heard_vote(N, N, V)
-
-    invariant [confirmed_implies_it_heard_at_least_one_node_accept]
-        forall N, V. node.confirmed(N,V) -> exists N2. N ~= N2 & node.heard_accept(N,N2,V)
-
     invariant [accepted_implies_at_least_one_node_voted]
         forall V. (exists N1. node.accepted(N1, V)) -> (exists N2. node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V . node.confirmed(N, V) -> node.accepted(N, V)
 
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . node.confirmed(N, V) ->

--- a/executable-models/model-2/proof.ivy
+++ b/executable-models/model-2/proof.ivy
@@ -13,56 +13,15 @@ axiom v1 ~= v0
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant [voted_or_not_voted] forall V, VAL. node.voted(V, VAL) | ~node.voted(V, VAL)
-
-    invariant [accepted_or_not_accepted] forall V, VAL. node.accepted(V, VAL) | ~node.accepted(V, VAL)
-
-    invariant [voted_implies_heard_itself_vote] forall V, VAL. node.voted(V, VAL) -> node.heard_vote(V, V, VAL)
-
-    invariant [accepted_implies_heard_itself_accept] forall V, VAL. node.accepted(V, VAL) -> node.heard_accept(V, V, VAL)
-
-    invariant [heard_vote_implies_voted]
-        forall SELF, OTHER, VAL. node.heard_vote(SELF, OTHER, VAL) -> node.voted(OTHER, VAL)
-
     invariant [heard_accept_implies_accepted]
         forall SELF, OTHER, VAL. node.heard_accept(SELF, OTHER, VAL) -> node.accepted(OTHER, VAL)
-
-    invariant [accept_means_at_least_one_vote]
-        forall SELF, VAL. node.accepted(SELF, VAL) -> (exists NODE. node.voted(NODE, VAL))
-
-    invariant [if_node_is_ready_to_accept_it_must_accept]
-        forall N, V . ~node.ready_to_accept_but_have_not_accepted(N, V)
-
-    invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        forall N, V . ~node.ready_to_confirm_but_have_not_confirmed(N, V)
-
-    invariant [if_accept_condition_1_then_must_accept]
-        forall V, VAL. node.accept_condition_1(V, VAL) -> node.accepted(V, VAL)
 
     invariant [if_accept_condition_2_then_must_accept]
         forall V, VAL. node.accept_condition_2(V, VAL) -> node.accepted(V, VAL)
 
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. node.accepted(N, V) -> node.heard_accept(N, N, V)
-
-    invariant [voted_implies_node_heard_itself_vote]
-        forall N, V. node.voted(N, V) -> node.heard_vote(N, N, V)
-
-    invariant [confirmed_implies_it_heard_at_least_one_node_accept]
-        forall N, V. node.confirmed(N,V) -> exists N2. N ~= N2 & node.heard_accept(N,N2,V)
-
-    invariant [accepted_implies_at_least_one_node_voted]
-        forall V. (exists N1. node.accepted(N1, V)) -> (exists N2. node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V . node.confirmed(N, V) -> node.accepted(N, V)
-
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . node.confirmed(N, V) ->
             (exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V))
-
-    invariant [if_there_exists_quorum_accepting_value_then_confirmed]
-        forall N, V. ((exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V)) -> node.confirmed(N, V))
 
     invariant [heard_quorum_accept_implies_confirmed]
         forall N1, V. (exists Q.

--- a/executable-models/model-3/proof.ivy
+++ b/executable-models/model-3/proof.ivy
@@ -9,60 +9,15 @@ include network
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant [voted_or_not_voted] forall V, VAL. node.voted(V, VAL) | ~node.voted(V, VAL)
-
-    invariant [accepted_or_not_accepted] forall V, VAL. node.accepted(V, VAL) | ~node.accepted(V, VAL)
-
-    invariant [heard_accept_or_not_heard_accept] forall V, W, VAL. node.heard_accept(V, W, VAL) | ~node.heard_accept(V, W, VAL)
-
-    invariant [heard_vote_or_not_heard_vote] forall V, W, VAL. node.heard_vote(V, W, VAL) | ~node.heard_vote(V, W, VAL)
-
-    invariant [voted_implies_heard_itself_vote] forall V, VAL. node.voted(V, VAL) -> node.heard_vote(V, V, VAL)
-
-    invariant [accepted_implies_heard_itself_accept] forall V, VAL. node.accepted(V, VAL) -> node.heard_accept(V, V, VAL)
-
-    invariant [heard_vote_implies_voted]
-        forall SELF, OTHER, VAL. node.heard_vote(SELF, OTHER, VAL) -> node.voted(OTHER, VAL)
-
     invariant [heard_accept_implies_accepted]
         forall SELF, OTHER, VAL. node.heard_accept(SELF, OTHER, VAL) -> node.accepted(OTHER, VAL)
-
-    invariant [accept_means_at_least_one_vote]
-        forall SELF, VAL. node.accepted(SELF, VAL) -> (exists NODE. node.voted(NODE, VAL))
-
-    invariant [if_node_is_ready_to_accept_it_must_accept]
-        ~forall N, V . node.ready_to_accept_but_have_not_accepted(N, V)
-
-    invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        ~forall N, V . node.ready_to_confirm_but_have_not_confirmed(N, V)
-
-    invariant [if_accept_condition_1_then_must_accept]
-        forall V, VAL. node.accept_condition_1(V, VAL) -> node.accepted(V, VAL)
 
     invariant [if_accept_condition_2_then_must_accept]
         forall V, VAL. node.accept_condition_2(V, VAL) -> node.accepted(V, VAL)
 
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. node.accepted(N, V) -> node.heard_accept(N, N, V)
-
-    invariant [voted_implies_node_heard_itself_vote]
-        forall N, V. node.voted(N, V) -> node.heard_vote(N, N, V)
-
-    invariant [confirmed_implies_it_heard_at_least_one_node_accept]
-        forall N, V. node.confirmed(N,V) -> exists N2. N ~= N2 & node.heard_accept(N,N2,V)
-
-    invariant [accepted_implies_at_least_one_node_voted]
-        forall V. (exists N1. node.accepted(N1, V)) -> (exists N2. node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V . node.confirmed(N, V) -> node.accepted(N, V)
-
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . node.confirmed(N, V) ->
             (exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V))
-
-    invariant [if_there_exists_quorum_accepting_value_then_confirmed]
-        forall N, V. ((exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V)) -> node.confirmed(N, V))
 
     invariant [heard_quorum_accept_implies_confirmed]
         forall N1, V. (exists Q.

--- a/executable-models/model-4/proof.ivy
+++ b/executable-models/model-4/proof.ivy
@@ -11,18 +11,6 @@ include network
 private {
     # NOTE: In this specific model, all well behaved nodes are intact and intertwined.
     # They are not generally true, so some of the invariants here will not hold in general.
-    invariant [voted_or_not_voted] forall V, VAL. node.voted(V, VAL) | ~node.voted(V, VAL)
-
-    invariant [accepted_or_not_accepted] forall V, VAL. node.accepted(V, VAL) | ~node.accepted(V, VAL)
-
-    invariant [heard_accept_or_not_heard_accept] forall V, W, VAL. node.heard_accept(V, W, VAL) | ~node.heard_accept(V, W, VAL)
-
-    invariant [heard_vote_or_not_heard_vote] forall V, W, VAL. node.heard_vote(V, W, VAL) | ~node.heard_vote(V, W, VAL)
-
-    invariant [voted_implies_heard_itself_vote] forall V, VAL. (node.well_behaved(V) & node.voted(V, VAL)) -> node.heard_vote(V, V, VAL)
-
-    invariant [accepted_implies_heard_itself_accept] forall V, VAL. (node.well_behaved(V) & node.accepted(V, VAL)) -> node.heard_accept(V, V, VAL)
-
     invariant [heard_vote_implies_voted]
         forall SELF, OTHER, VAL. (node.well_behaved(SELF) & node.well_behaved(OTHER) & node.heard_vote(SELF, OTHER, VAL)) -> node.voted(OTHER, VAL)
 
@@ -32,38 +20,12 @@ private {
     invariant [accept_means_at_least_one_vote]
         forall SELF, VAL. (node.well_behaved(SELF) & node.accepted(SELF, VAL)) -> (exists NODE. node.well_behaved(NODE) & node.voted(NODE, VAL))
 
-    invariant [if_node_is_ready_to_accept_it_must_accept]
-        forall N, V. node.well_behaved(N) -> ~node.ready_to_accept_but_have_not_accepted(N, V)
-
-    invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        forall N, V. node.well_behaved(N) -> ~node.ready_to_confirm_but_have_not_confirmed(N, V)
-
-    invariant [if_accept_condition_1_then_must_accept]
-        forall V, VAL. (node.well_behaved(V) & node.accept_condition_1(V, VAL)) -> node.accepted(V, VAL)
-
     invariant [if_accept_condition_2_then_must_accept]
         forall V, VAL. (node.well_behaved(V) & node.accept_condition_2(V, VAL)) -> node.accepted(V, VAL)
-
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. (node.well_behaved(N) & node.accepted(N, V)) -> node.heard_accept(N, N, V)
-
-    invariant [voted_implies_node_heard_itself_vote]
-        forall N, V. (node.well_behaved(N) & node.voted(N, V)) -> node.heard_vote(N, N, V)
-
-    invariant [confirmed_implies_it_heard_at_least_one_node_accept]
-        forall N, V. (node.well_behaved(N) & node.confirmed(N,V)) -> exists N2. N ~= N2 & node.well_behaved(N2) & node.heard_accept(N,N2,V)
-    invariant [accepted_implies_at_least_one_node_voted]
-        forall V. (exists N1. node.well_behaved(N1) & node.accepted(N1, V)) -> (exists N2. node.well_behaved(N2) & node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V. (node.well_behaved(N) & node.confirmed(N, V)) -> node.accepted(N, V)
 
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . (node.well_behaved(N) & node.confirmed(N, V)) ->
             (exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V))
-
-    invariant [if_there_exists_quorum_accepting_value_then_confirmed]
-        forall N, V. ((node.well_behaved(N) & exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V)) -> node.confirmed(N, V))
 
     invariant [heard_quorum_accept_implies_confirmed]
         forall N1, V. (node.well_behaved(N1) &

--- a/executable-models/model-5/proof.ivy
+++ b/executable-models/model-5/proof.ivy
@@ -9,32 +9,11 @@ include network
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant [voted_or_not_voted] forall V, VAL. node.voted(V, VAL) | ~node.voted(V, VAL)
-
-    invariant [accepted_or_not_accepted] forall V, VAL. node.accepted(V, VAL) | ~node.accepted(V, VAL)
-
-    invariant [heard_accept_or_not_heard_accept] forall V, W, VAL. node.heard_accept(V, W, VAL) | ~node.heard_accept(V, W, VAL)
-
-    invariant [heard_vote_or_not_heard_vote] forall V, W, VAL. node.heard_vote(V, W, VAL) | ~node.heard_vote(V, W, VAL)
-
-    invariant [voted_implies_heard_itself_vote] forall V, VAL. node.voted(V, VAL) -> node.heard_vote(V, V, VAL)
-
-    invariant [accepted_implies_heard_itself_accept] forall V, VAL. node.accepted(V, VAL) -> node.heard_accept(V, V, VAL)
-
     invariant [heard_vote_implies_voted]
         forall SELF, OTHER, VAL. node.heard_vote(SELF, OTHER, VAL) -> node.voted(OTHER, VAL)
 
     invariant [heard_accept_implies_accepted]
         forall SELF, OTHER, VAL. node.heard_accept(SELF, OTHER, VAL) -> node.accepted(OTHER, VAL)
-
-    invariant [accept_means_at_least_one_vote]
-        forall SELF, VAL. node.accepted(SELF, VAL) -> (exists NODE. node.voted(NODE, VAL))
-
-    invariant [if_node_is_ready_to_accept_it_must_accept]
-        forall N, V. ~node.ready_to_accept_but_have_not_accepted(N, V)
-
-    invariant [if_node_is_ready_to_confirm_it_must_confirm]
-        forall N, V. ~node.ready_to_confirm_but_have_not_confirmed(N, V)
 
     invariant [if_accept_condition_1_then_must_accept]
         forall V, VAL. (node.accept_condition_1(V, VAL)) -> node.accepted(V, VAL)
@@ -42,17 +21,8 @@ private {
     invariant [if_accept_condition_2_then_must_accept]
         forall V, VAL. (node.accept_condition_2(V, VAL)) -> node.accepted(V, VAL)
 
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. (node.accepted(N, V)) -> node.heard_accept(N, N, V)
-
     invariant [voted_implies_node_heard_itself_vote]
         forall N, V. node.voted(N, V) -> node.heard_vote(N, N, V)
-
-    invariant [accepted_implies_at_least_one_node_voted]
-        forall V. (exists N1. node.accepted(N1, V)) -> (exists N2. node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V. node.confirmed(N, V) -> node.accepted(N, V)
 
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . node.confirmed(N, V) ->

--- a/executable-models/model-6/proof.ivy
+++ b/executable-models/model-6/proof.ivy
@@ -9,50 +9,17 @@ include network
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant [voted_or_not_voted] forall V, VAL. node.voted(V, VAL) | ~node.voted(V, VAL)
-
-    invariant [accepted_or_not_accepted] forall V, VAL. node.accepted(V, VAL) | ~node.accepted(V, VAL)
-
-    invariant [heard_accept_or_not_heard_accept] forall V, W, VAL. node.heard_accept(V, W, VAL) | ~node.heard_accept(V, W, VAL)
-
-    invariant [heard_vote_or_not_heard_vote] forall V, W, VAL. node.heard_vote(V, W, VAL) | ~node.heard_vote(V, W, VAL)
-
-    invariant [voted_implies_heard_itself_vote] forall V, VAL. (node.intact(V) & node.voted(V, VAL)) -> node.heard_vote(V, V, VAL)
-
-    invariant [accepted_implies_heard_itself_accept] forall V, VAL. (node.intact(V) & node.accepted(V, VAL)) -> node.heard_accept(V, V, VAL)
-
     invariant [heard_vote_implies_voted]
         forall SELF, OTHER, VAL. (node.intact(SELF) & node.intact(OTHER) & node.heard_vote(SELF, OTHER, VAL)) -> node.voted(OTHER, VAL)
 
     invariant [heard_accept_implies_accepted]
         forall SELF, OTHER, VAL. (node.intact(SELF) & node.intact(OTHER) & node.heard_accept(SELF, OTHER, VAL)) -> node.accepted(OTHER, VAL)
 
-    invariant [accept_means_at_least_one_vote]
-        forall SELF, VAL. (node.intact(SELF) & node.accepted(SELF, VAL)) -> (exists NODE. node.intact(NODE) & node.voted(NODE, VAL))
-
     invariant [if_node_is_ready_to_accept_it_must_accept]
         forall NODE. (node.intact(NODE) -> forall VAL. ~node.ready_to_accept_but_have_not_accepted(NODE, VAL))
 
     invariant [if_node_is_ready_to_confirm_it_must_confirm]
         forall NODE. (node.intact(NODE) -> forall VAL. ~node.ready_to_confirm_but_have_not_confirmed(NODE, VAL))
-
-    invariant [if_accept_condition_1_then_must_accept]
-        forall V, VAL. (node.intact(V) & node.accept_condition_1(V, VAL)) -> node.accepted(V, VAL)
-
-    invariant [if_accept_condition_2_then_must_accept]
-        forall V, VAL. (node.intact(V) & node.accept_condition_2(V, VAL)) -> node.accepted(V, VAL)
-
-    invariant [accepted_implies_node_heard_itself_accept]
-        forall N, V. (node.intact(N) & node.accepted(N, V)) -> node.heard_accept(N, N, V)
-
-    invariant [voted_implies_node_heard_itself_vote]
-        forall N, V. (node.intact(N) & node.voted(N, V)) -> node.heard_vote(N, N, V)
-
-    invariant [accepted_implies_at_least_one_node_voted]
-        forall V. (exists N1. node.intact(N1) & node.accepted(N1, V)) -> (exists N2. node.intact(N2) & node.voted(N2, V))
-
-    invariant [confirmed_implies_accepted]
-        forall N, V. (node.intact(N) & node.confirmed(N, V)) -> node.accepted(N, V)
 
     relation heard_my_quorum_accept(N:id_t, V:val_t)
     definition heard_my_quorum_accept(N, V) =
@@ -61,12 +28,6 @@ private {
     invariant [confirmed_implies_there_exists_quorum_accepting_value]
         forall N, V . (node.intact(N) & node.confirmed(N, V)) ->
             heard_my_quorum_accept(N, V)
-
-    invariant [if_there_exists_quorum_accepting_value_then_confirmed]
-        forall N, V. ((node.intact(N) & exists Q. node.is_quorum(Q) & node.member(N, Q) & node.heard_set_accept(N, Q, V)) -> node.confirmed(N, V))
-
-    invariant [heard_quorum_accept_implies_confirmed]
-        forall N1, V. (node.intact(N1) & (heard_my_quorum_accept(N1, V))) -> node.confirmed(N1, V)
 }
 
 invariant [confirm_same_after_sufficient_messages]

--- a/executable-models/nomination-model-1/proof.ivy
+++ b/executable-models/nomination-model-1/proof.ivy
@@ -10,17 +10,7 @@ include assertion
 
 # We need a bunch of auxiliary invariants for the prover to avoid spurious CTIs
 private {
-    invariant [heard_vote_implies_voted] forall SELF, OTHER, VAL . assertion.heard_vote_implies_voted(SELF, OTHER, VAL)
-    invariant [heard_accept_implies_accepted] forall SELF, OTHER, VAL . assertion.heard_accept_implies_accepted(SELF, OTHER, VAL)
-    invariant [accept_means_at_least_one_vote] forall SELF, VAL . assertion.accept_means_at_least_one_vote(SELF, VAL)
     invariant [if_node_is_ready_to_accept_it_must_accept] forall N, V . assertion.if_node_is_ready_to_accept_it_must_accept(N, V)
-    invariant [if_node_is_ready_to_confirm_it_must_confirm] forall N, V . assertion.if_node_is_ready_to_confirm_it_must_confirm(N, V)
-    invariant [accepted_implies_node_heard_itself_accept] forall N, V . assertion.accepted_implies_node_heard_itself_accept(N, V)
-    invariant [voted_implies_node_heard_itself_vote] forall N, V . assertion.voted_implies_node_heard_itself_vote(N, V)
-    invariant [confirmed_implies_it_heard_at_least_one_node_accept] forall N, V . assertion.confirmed_implies_it_heard_at_least_one_node_accept(N, V)
-    invariant [accepted_implies_at_least_one_node_voted] forall V . assertion.accepted_implies_at_least_one_node_voted(V)
-    invariant [confirmed_implies_accepted] forall N, V . assertion.confirmed_implies_accepted(N, V)
-    invariant [confirmed_implies_there_exists_quorum_accepting_value] forall N, V . assertion.confirmed_implies_there_exists_quorum_accepting_value(N, V)
     invariant [heard_quorum_accept_implies_confirmed] forall N, V . assertion.heard_quorum_accept_implies_confirmed(N, V)
 }
 


### PR DESCRIPTION
It turns out that we have so many more private invariants which act as lemmas in `proof.ivy` than we need. I went through many existing models and removed many of them. A few things I've noticed:

- Removing invariants doesn't mean it'll be faster, though it is often the case.
- Removing some invariants leads to Ivy running forever in an extremely non-trivial way. I guess this means that, when the prover doesn't terminate, there _may_ be some magical invariant that we can add to make things work, though I have no idea how one would find it.
- Some proofs took 6-7 seconds on my computer, but after removing unnecessary invariants, all of the proofs seem to terminate within 1-2 seconds.
- It seems that, on average, an invariant that a local node can't check is more important. (e.g., When a node accepts a value, the node can't make sure that at least one node in the network voted for it with certainty in general. However, it can check if it has accepted before confirming a value. Ivy _seems_ to find the former more useful than the latter on average.)